### PR TITLE
[user-service]feature/#1-user-error-custom

### DIFF
--- a/src/main/java/f4/auth/global/constant/CustomErrorCode.java
+++ b/src/main/java/f4/auth/global/constant/CustomErrorCode.java
@@ -1,0 +1,15 @@
+package f4.auth.global.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CustomErrorCode {
+
+    ALREADY_REGISTERED_USER("/user/v1/signup", 400, "이미 회원 가입한 계정이 존재합니다.");
+
+    private final String path;
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/f4/auth/global/exception/CustomException.java
+++ b/src/main/java/f4/auth/global/exception/CustomException.java
@@ -1,0 +1,13 @@
+package f4.auth.global.exception;
+
+import f4.auth.global.constant.CustomErrorCode;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException{
+    private final CustomErrorCode customErrorCode;
+    public CustomException(CustomErrorCode customErrorCode){
+        super(customErrorCode.getMessage());
+        this.customErrorCode = customErrorCode;
+    }
+}

--- a/src/main/java/f4/auth/global/exception/ErrorDetails.java
+++ b/src/main/java/f4/auth/global/exception/ErrorDetails.java
@@ -1,0 +1,12 @@
+package f4.auth.global.exception;
+
+import lombok.Builder;
+import lombok.Setter;
+
+@Setter
+@Builder
+public class ErrorDetails {
+    private String path;
+    private int code;
+    private String message;
+}

--- a/src/main/java/f4/auth/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/f4/auth/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package f4.auth.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler({CustomException.class})
+    public ResponseEntity customExceptionHandler(CustomException e) {
+        return new ResponseEntity(
+                ErrorDetails.builder()
+                        .path(e.getCustomErrorCode().getPath())
+                        .code(e.getCustomErrorCode().getCode())
+                        .message(e.getCustomErrorCode().getMessage())
+                        .build(),
+                HttpStatus.BAD_REQUEST
+        );
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 구현 기능
User-Service에서 사용될 exception 커스텀 (RuntimeException 상속) 및 GlobalExcepitonHandler를 통한 exception 공통 처리

## 🤷🏻 동작 원리
1. CustomException이 발생 시 GlobalExceptionHandler가 캐치
2. 클라이언트측에 Response 해주기 위한 ErrorDetails에 exception 정보 매핑
3. 클라이언트에게 정보 전달

```
Response - ErrorDetails

path : [api-url]
code : 코드 번호
message : 어떠한 에러가 발생했는지  
```

## ✍🏻 To do
- [x] 에러를 정의하기 위한 enum 클래스 정의 
- [x] 에러 공통 처리를 위한 ExceptionHandler 구현

## 관련 이슈
- Closed #2 



