### PR TITLE
[user-service]feature/#2-user-signup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.modelmapper:modelmapper:2.4.2'
 
 	// jwt 설
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
@@ -38,11 +39,11 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	compileOnly 'org.projectlombok:lombok'
-
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-
 	annotationProcessor 'org.projectlombok:lombok'
+
+	runtimeOnly 'com.mysql:mysql-connector-j' // 개발 환경에서 사용하는 DB (Mysql)
+	runtimeOnly 'com.h2database:h2' // 테스트 코드 작성시 사용할 DB (H2)
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/src/main/java/f4/auth/domain/user/constant/Role.java
+++ b/src/main/java/f4/auth/domain/user/constant/Role.java
@@ -1,0 +1,6 @@
+package f4.auth.domain.user.constant;
+
+public enum Role {
+
+    USER, ADMIN;
+}

--- a/src/main/java/f4/auth/domain/user/controller/MemberController.java
+++ b/src/main/java/f4/auth/domain/user/controller/MemberController.java
@@ -1,0 +1,39 @@
+package f4.auth.domain.user.controller;
+
+import f4.auth.domain.user.dto.request.SignupRequestDto;
+import f4.auth.domain.user.persist.repository.MemberRepository;
+import f4.auth.domain.user.service.MemberService;
+import f4.auth.global.constant.CustomErrorCode;
+import f4.auth.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/auth/v1")
+public class MemberController {
+
+    private final MemberService memberService;
+    private final MemberRepository memberRepository;
+
+    @GetMapping("/health-check")
+    public String status() {
+        return "It's Working in Auth-Service";
+    }
+
+    @PostMapping("/signup")
+    public String register(@Valid @RequestBody SignupRequestDto signupRequestDto) {
+
+        memberRepository.findByEmail(signupRequestDto.getEmail())
+                .ifPresent(data -> {
+                    throw new CustomException(CustomErrorCode.ALREADY_REGISTERED_USER);
+                });
+
+        memberService.register(signupRequestDto);
+        return "회원 가입에 성공하셨습니다.";
+    }
+}

--- a/src/main/java/f4/auth/domain/user/dto/request/SignupRequestDto.java
+++ b/src/main/java/f4/auth/domain/user/dto/request/SignupRequestDto.java
@@ -1,0 +1,42 @@
+package f4.auth.domain.user.dto.request;
+
+import lombok.*;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SignupRequestDto {
+
+    @NotBlank(message = "회원 이름은 필수 입력 항목입니다.")
+    private String username;
+
+    @NotBlank(message = "성별은 필수 입력 항목입니다.")
+    @Pattern(regexp = "[MW]")
+    private String gender;
+
+    @NotBlank(message = "생년월일은 필수 입력 항목입니다.")
+    @Pattern(regexp = "^\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])$", message = "잘못된 생년월일 양식입니다.")
+    private String birth;
+
+    @NotBlank(message = "주소는 필수 입력 항목입니다.")
+    private String address;
+
+    @NotBlank(message = "email은 필수 입력 항목입니다.")
+    @Email
+    private String email;
+
+    @NotBlank(message = "패스워드는 필수 입력 항목입니다.")
+    @Length(max = 30, message = "패스워드는 최대 30자리까지 입력하실 수 있습니다.")
+    private String password;
+
+    @NotBlank(message = "핸드폰 번호는 필수 입력 항목입니다.")
+    @Pattern(regexp = "^\\d{2,3}-\\d{3,4}-\\d{4}$", message = "핸드폰 번호의 양식과 맞지 않습니다. 01x-xxx(x)-xxxx")
+    private String phoneNumber;
+}

--- a/src/main/java/f4/auth/domain/user/persist/entity/Member.java
+++ b/src/main/java/f4/auth/domain/user/persist/entity/Member.java
@@ -1,0 +1,54 @@
+package f4.auth.domain.user.persist.entity;
+
+import f4.auth.domain.user.constant.Role;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name")
+    private String username;
+
+    @Column(name = "gender")
+    private String gender;
+
+    @Column(name = "birth")
+    private String birth;
+
+    @Column(name = "address")
+    private String address;
+
+    @Column(name = "email", unique = true)
+    private String email;
+
+    @Column(name = "password")
+    private String password;
+
+    @Column(name = "phone_number")
+    private String phoneNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role")
+    private Role role;
+
+    @CreatedDate
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/f4/auth/domain/user/persist/repository/MemberRepository.java
+++ b/src/main/java/f4/auth/domain/user/persist/repository/MemberRepository.java
@@ -1,0 +1,13 @@
+package f4.auth.domain.user.persist.repository;
+
+import f4.auth.domain.user.persist.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/f4/auth/domain/user/service/MemberService.java
+++ b/src/main/java/f4/auth/domain/user/service/MemberService.java
@@ -1,0 +1,8 @@
+package f4.auth.domain.user.service;
+
+import f4.auth.domain.user.dto.request.SignupRequestDto;
+
+public interface MemberService {
+
+    void register(SignupRequestDto signupRequestDto);
+}

--- a/src/main/java/f4/auth/domain/user/service/MemberServiceImpl.java
+++ b/src/main/java/f4/auth/domain/user/service/MemberServiceImpl.java
@@ -1,0 +1,40 @@
+package f4.auth.domain.user.service;
+
+import f4.auth.domain.user.dto.request.SignupRequestDto;
+import f4.auth.domain.user.persist.entity.Member;
+import f4.auth.domain.user.persist.repository.MemberRepository;
+import f4.auth.global.utils.Encryptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+import static f4.auth.domain.user.constant.Role.USER;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+    private final Encryptor crypto;
+
+    @Override
+    public void register(SignupRequestDto signupRequestDto) {
+        String encryptPassword = crypto.encrypt(signupRequestDto.getPassword());
+
+        Member save = memberRepository.save(
+                Member.builder()
+                        .username(signupRequestDto.getUsername())
+                        .gender(signupRequestDto.getGender())
+                        .birth(signupRequestDto.getBirth())
+                        .address(signupRequestDto.getAddress())
+                        .email(signupRequestDto.getEmail())
+                        .password(encryptPassword)
+                        .phoneNumber(signupRequestDto.getPhoneNumber())
+                        .role(USER)
+                        .createdAt(LocalDateTime.now())
+                        .updatedAt(LocalDateTime.now())
+                        .build()
+        );
+    }
+}

--- a/src/main/java/f4/auth/global/constant/CustomErrorCode.java
+++ b/src/main/java/f4/auth/global/constant/CustomErrorCode.java
@@ -7,7 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum CustomErrorCode {
 
-    ALREADY_REGISTERED_USER("/user/v1/signup", 400, "이미 회원 가입한 계정이 존재합니다.");
+    ALREADY_REGISTERED_USER("/user/v1/signup", 400, "이미 회원 가입한 계정이 존재합니다."),
+    CAN_NOT_ENCRYPT("/user/v1/signup", 400, "비밀번호를 암호화 할 수 없습니다.");
+
 
     private final String path;
     private final int code;

--- a/src/main/java/f4/auth/global/exception/CustomException.java
+++ b/src/main/java/f4/auth/global/exception/CustomException.java
@@ -4,9 +4,11 @@ import f4.auth.global.constant.CustomErrorCode;
 import lombok.Getter;
 
 @Getter
-public class CustomException extends RuntimeException{
+public class CustomException extends RuntimeException {
+
     private final CustomErrorCode customErrorCode;
-    public CustomException(CustomErrorCode customErrorCode){
+
+    public CustomException(CustomErrorCode customErrorCode) {
         super(customErrorCode.getMessage());
         this.customErrorCode = customErrorCode;
     }

--- a/src/main/java/f4/auth/global/exception/ErrorDetails.java
+++ b/src/main/java/f4/auth/global/exception/ErrorDetails.java
@@ -1,11 +1,14 @@
 package f4.auth.global.exception;
 
 import lombok.Builder;
+import lombok.Getter;
 import lombok.Setter;
 
+@Getter
 @Setter
 @Builder
 public class ErrorDetails {
+
     private String path;
     private int code;
     private String message;

--- a/src/main/java/f4/auth/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/f4/auth/global/exception/GlobalExceptionHandler.java
@@ -1,22 +1,37 @@
 package f4.auth.global.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.security.NoSuchAlgorithmException;
+
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler({CustomException.class})
-    public ResponseEntity customExceptionHandler(CustomException e) {
-        return new ResponseEntity(
+    public ResponseEntity<?> customExceptionHandler(CustomException e) {
+        return new ResponseEntity<>(
                 ErrorDetails.builder()
                         .path(e.getCustomErrorCode().getPath())
                         .code(e.getCustomErrorCode().getCode())
                         .message(e.getCustomErrorCode().getMessage())
                         .build(),
                 HttpStatus.BAD_REQUEST
+        );
+    }
+
+    @ExceptionHandler({NoSuchAlgorithmException.class})
+    public ResponseEntity<?> noSuchAlgorithmExceptionHandler(NoSuchAlgorithmException e) {
+        return new ResponseEntity(
+                ErrorDetails.builder()
+                        .code(500)
+                        .message("암호화를 수행할 수 없습니다.")
+                        .build(),
+                HttpStatus.INTERNAL_SERVER_ERROR
         );
     }
 }

--- a/src/main/java/f4/auth/global/utils/Encryptor.java
+++ b/src/main/java/f4/auth/global/utils/Encryptor.java
@@ -1,0 +1,34 @@
+package f4.auth.global.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Objects;
+
+@Slf4j
+@Component
+public class Encryptor {
+
+    // SHA-256 알고리즘을 활용한 비밀번호 암호화
+    // 단반향 알고리즘이기 때문에 혹시나 비밀번호를 잃어버린 경우 비밀번호를 재발급 해준다.
+    public String encrypt(String text) {
+        MessageDigest md = null;
+        try {
+            md = MessageDigest.getInstance("SHA-256");
+            md.update(text.getBytes());
+        } catch (NoSuchAlgorithmException e) {
+            log.warn("error : { }", e);
+        }
+        return bytesToHex(Objects.requireNonNull(md).digest());
+    }
+
+    private String bytesToHex(byte[] bytes) {
+        StringBuilder builder = new StringBuilder();
+        for (byte b : bytes) {
+            builder.append(String.format("%02x", b));
+        }
+        return builder.toString();
+    }
+}

--- a/src/test/java/f4/auth/domain/user/controller/MemberControllerTest.java
+++ b/src/test/java/f4/auth/domain/user/controller/MemberControllerTest.java
@@ -1,0 +1,112 @@
+package f4.auth.domain.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import f4.auth.domain.user.dto.request.SignupRequestDto;
+import f4.auth.domain.user.persist.entity.Member;
+import f4.auth.domain.user.persist.repository.MemberRepository;
+import f4.auth.domain.user.service.MemberService;
+import f4.auth.global.exception.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.jdbc.EmbeddedDatabaseConnection;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+@ExtendWith(SpringExtension.class)
+@AutoConfigureTestDatabase(connection = EmbeddedDatabaseConnection.H2)
+@DisplayName("Member-Controller 테스트")
+class MemberControllerTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private MemberService memberService;
+
+    @Autowired
+
+    private MockMvc mockMvc;
+
+
+    @BeforeEach
+    public void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(new MemberController(memberService, memberRepository))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    @DisplayName("회원가입 성공 테스트")
+    void success_registered() throws Exception {
+        // given
+        SignupRequestDto signupRequestDto = SignupRequestDto.builder()
+                .username("테스트 유저1")
+                .gender("M")
+                .birth("1996-12-16")
+                .address("서울시 거마로 56 107-302")
+                .email("soohyuk96@naver.com")
+                .password("f4loveyou")
+                .phoneNumber("010-3237-4176")
+                .build();
+
+        // then
+        mockMvc.perform(post("/auth/v1/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(signupRequestDto))
+                        .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("기존에 있는 회원")
+    void 기존에_회원가입한_이메일() throws Exception {
+        //given
+        SignupRequestDto signupRequestDto = SignupRequestDto.builder()
+                .username("테스트 유저1")
+                .gender("M")
+                .birth("1996-12-16")
+                .address("서울시 거마로 56 107-302")
+                .email("soohyuk96@naver.com")
+                .password("f4loveyou")
+                .phoneNumber("010-3237-4176")
+                .build();
+
+        //when
+        when(memberRepository.findByEmail(any())).thenReturn(Optional.of(Member.builder().email("soohyuk96@naver.com").build()));
+
+        // then
+        mockMvc.perform(post("/auth/v1/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(signupRequestDto))
+                        .accept(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.path").value("/user/v1/signup"))
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("이미 회원 가입한 계정이 존재합니다."))
+                .andReturn();
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 구현 기능
> 회원 가입 로직 및 사용자 비밀번호를 암호화하기 위한 암호화 유틸 클래스 생성

## 🤷🏻 동작 원리
1. SignupRequestDto의 Validation 어노테이션을 통한 데이터 유효성 검사
2. 기존 가입 여부 파악
3. 비밀번호를 암호화
4. 데이터베이스에 저장

## ✍🏻 To do
- [x] : 비밀번호를 암호화하기 위한 Encryptor Utill Class 생성 
- [x] : 전체적인 프로젝트 패키지 구조 구성
- [x] : 회원 가입 로직 작성
- [x] : 컨트롤러 정상 처리 및 Exception 처리 확인을 위한 테스트 코드 작성


## 관련 이슈
- Closed #4 



