### PR TITLE
[user-service]feature/#3-user-login

### DIFF
--- a/src/main/java/f4/auth/domain/user/controller/AuthController.java
+++ b/src/main/java/f4/auth/domain/user/controller/AuthController.java
@@ -4,6 +4,7 @@ import f4.auth.domain.user.dto.request.LoginRequestDto;
 import f4.auth.domain.user.dto.response.TokenResponseDto;
 import f4.auth.domain.user.service.AuthService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -16,8 +17,14 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public TokenResponseDto login(@Valid @RequestBody LoginRequestDto dto) {
-        return authService.login(dto);
+    public ResponseEntity<?> login(@Valid @RequestBody LoginRequestDto dto) {
+        return ResponseEntity.ok(authService.login(dto));
+    }
+
+
+    @PutMapping("/login")
+    public TokenResponseDto reIssue(@RequestHeader(value = "Refresh-Token") String rtk) {
+        return authService.reIssue(rtk);
     }
 
 }

--- a/src/main/java/f4/auth/domain/user/controller/AuthController.java
+++ b/src/main/java/f4/auth/domain/user/controller/AuthController.java
@@ -1,0 +1,23 @@
+package f4.auth.domain.user.controller;
+
+import f4.auth.domain.user.dto.request.LoginRequestDto;
+import f4.auth.domain.user.dto.response.TokenResponseDto;
+import f4.auth.domain.user.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/auth/v1")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public TokenResponseDto login(@Valid @RequestBody LoginRequestDto dto) {
+        return authService.login(dto);
+    }
+
+}

--- a/src/main/java/f4/auth/domain/user/controller/MemberController.java
+++ b/src/main/java/f4/auth/domain/user/controller/MemberController.java
@@ -30,7 +30,7 @@ public class MemberController {
 
         memberRepository.findByEmail(signupRequestDto.getEmail())
                 .ifPresent(data -> {
-                    throw new CustomException(CustomErrorCode.ALREADY_REGISTERED_USER);
+                    throw new CustomException(CustomErrorCode.ALREADY_REGISTERED_MEMBER);
                 });
 
         memberService.register(signupRequestDto);

--- a/src/main/java/f4/auth/domain/user/dto/request/CreateTokenDto.java
+++ b/src/main/java/f4/auth/domain/user/dto/request/CreateTokenDto.java
@@ -1,0 +1,15 @@
+package f4.auth.domain.user.dto.request;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CreateTokenDto {
+
+    private Long id;
+    private String username;
+    private String email;
+}

--- a/src/main/java/f4/auth/domain/user/dto/request/LoginRequestDto.java
+++ b/src/main/java/f4/auth/domain/user/dto/request/LoginRequestDto.java
@@ -1,0 +1,17 @@
+package f4.auth.domain.user.dto.request;
+
+import lombok.*;
+
+import javax.validation.constraints.Email;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class LoginRequestDto {
+
+    @Email
+    private String email;
+    private String password;
+}

--- a/src/main/java/f4/auth/domain/user/dto/response/TokenResponseDto.java
+++ b/src/main/java/f4/auth/domain/user/dto/response/TokenResponseDto.java
@@ -1,0 +1,16 @@
+package f4.auth.domain.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+public class TokenResponseDto {
+
+    @Builder.Default
+    private String grantType = "Bearer";
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/f4/auth/domain/user/service/AuthService.java
+++ b/src/main/java/f4/auth/domain/user/service/AuthService.java
@@ -1,0 +1,10 @@
+package f4.auth.domain.user.service;
+
+import f4.auth.domain.user.dto.request.LoginRequestDto;
+import f4.auth.domain.user.dto.response.TokenResponseDto;
+
+public interface AuthService {
+
+    TokenResponseDto login(LoginRequestDto loginDto);
+    TokenResponseDto getNewAccessToken(String rtk);
+}

--- a/src/main/java/f4/auth/domain/user/service/AuthService.java
+++ b/src/main/java/f4/auth/domain/user/service/AuthService.java
@@ -6,5 +6,5 @@ import f4.auth.domain.user.dto.response.TokenResponseDto;
 public interface AuthService {
 
     TokenResponseDto login(LoginRequestDto loginDto);
-    TokenResponseDto getNewAccessToken(String rtk);
+    TokenResponseDto reIssue(String rtk);
 }

--- a/src/main/java/f4/auth/domain/user/service/AuthServiceImpl.java
+++ b/src/main/java/f4/auth/domain/user/service/AuthServiceImpl.java
@@ -1,0 +1,65 @@
+package f4.auth.domain.user.service;
+
+import f4.auth.domain.user.dto.request.CreateTokenDto;
+import f4.auth.domain.user.dto.request.LoginRequestDto;
+import f4.auth.domain.user.dto.response.TokenResponseDto;
+import f4.auth.domain.user.persist.entity.Member;
+import f4.auth.domain.user.persist.repository.MemberRepository;
+import f4.auth.global.constant.CustomErrorCode;
+import f4.auth.global.exception.CustomException;
+import f4.auth.global.redis.RedisService;
+import f4.auth.global.security.jwt.JwtTokenProvider;
+import f4.auth.global.security.jwt.JwtValidateService;
+import f4.auth.global.utils.Encryptor;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisService redisService;
+    private final JwtValidateService jwtValidateService;
+    private final MemberRepository memberRepository;
+    private final Encryptor encryptor;
+    private final ModelMapper modelMapper;
+
+    @Value("${jwt.token.access-expiration-time}")
+    private Long atkDuration;
+
+    @Value("${jwt.token.refresh-expiration-time}")
+    private Long rtkDuration;
+
+    @Override
+    @Transactional
+    public TokenResponseDto login(LoginRequestDto loginDto) {
+        Member member = memberRepository.findByEmail(loginDto.getEmail())
+                .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_MEMBER));
+
+        if (!encryptor.matchers(loginDto.getPassword(), member.getPassword())) {
+            throw new CustomException(CustomErrorCode.NOT_VALID_LOGIN_PASSWORD);
+        }
+        CreateTokenDto createTokenDto = modelMapper.map(member, CreateTokenDto.class);
+
+        final String atk = jwtTokenProvider.createAccessToken(createTokenDto);
+        final String rtk = jwtTokenProvider.createRefreshToken(createTokenDto);
+        redisService.setDataExpire(loginDto.getEmail(), rtk, Duration.ofMillis(atkDuration));
+
+
+        return TokenResponseDto.builder()
+                .accessToken(atk)
+                .refreshToken(rtk)
+                .build();
+    }
+
+    @Override
+    public TokenResponseDto getNewAccessToken(String rtk) {
+        return null;
+    }
+}

--- a/src/main/java/f4/auth/global/config/MapperConfig.java
+++ b/src/main/java/f4/auth/global/config/MapperConfig.java
@@ -1,0 +1,14 @@
+package f4.auth.global.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MapperConfig {
+
+    @Bean
+    public ModelMapper modelMapper() {
+        return new ModelMapper();
+    }
+}

--- a/src/main/java/f4/auth/global/constant/CustomErrorCode.java
+++ b/src/main/java/f4/auth/global/constant/CustomErrorCode.java
@@ -7,8 +7,23 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum CustomErrorCode {
 
-    ALREADY_REGISTERED_USER("/user/v1/signup", 400, "이미 회원 가입한 계정이 존재합니다."),
-    CAN_NOT_ENCRYPT("/user/v1/signup", 400, "비밀번호를 암호화 할 수 없습니다.");
+    // Bad Request 400
+    ALREADY_REGISTERED_MEMBER("/user/v1/signup", 400, "이미 회원 가입한 계정이 존재합니다."),
+    CAN_NOT_ENCRYPT("/user/v1/signup", 400, "비밀번호를 암호화 할 수 없습니다."),
+    NOT_VALID_LOGIN_PASSWORD("/user/v1/login", 400, "비밀번호가 틀렸습니다."),
+
+    // Unathorized 401
+    INVALID_ACCESS_TOKEN("user/v1/login" ,401, "잘못된 토큰 입니다"),
+    UNSUPPORTED_TOKEN("user/v1/login",401, "지원하지 않는 토큰입니다"),
+    EXPIRED_ACCESS_TOKEN("user/v1/login",401, "만료된 엑세스토큰 입니다"),
+    EXPIRED_REFRESH_TOKEN("user/v1/login",401, "만료된 리프레시토큰 입니다"),
+    EMPTY_ACCESS_TOKEN("user/v1/login",400, "토큰이 비어있습니다"),
+
+    // Forbidden 402
+
+
+    // Not Found 404
+    NOT_FOUND_MEMBER("/user/v1/login", 404, "해당 회원을 찾을 수 없습니다.");
 
 
     private final String path;

--- a/src/main/java/f4/auth/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/f4/auth/global/exception/GlobalExceptionHandler.java
@@ -14,6 +14,9 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler({CustomException.class})
     public ResponseEntity<?> customExceptionHandler(CustomException e) {
+        log.error("errorCode: {}, path: {}, message",
+                e.getCustomErrorCode().getCode(), e.getCustomErrorCode().getPath(), e.getCustomErrorCode().getMessage());
+
         return new ResponseEntity<>(
                 ErrorDetails.builder()
                         .path(e.getCustomErrorCode().getPath())

--- a/src/main/java/f4/auth/global/redis/RedisConfig.java
+++ b/src/main/java/f4/auth/global/redis/RedisConfig.java
@@ -1,0 +1,35 @@
+package f4.auth.global.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/f4/auth/global/redis/RedisService.java
+++ b/src/main/java/f4/auth/global/redis/RedisService.java
@@ -1,0 +1,45 @@
+package f4.auth.global.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final RedisTemplate<String, String> blackListTemplate;
+
+    public String getData(String key) {
+        ValueOperations<String, String> operations = stringRedisTemplate.opsForValue();
+        return operations.get(key);
+    }
+
+    public void setData(String key, String value) {
+        ValueOperations<String, String> operations = stringRedisTemplate.opsForValue();
+        operations.set(key, value);
+    }
+
+    public void setDataExpire(String key, String value, Duration duration) {
+        ValueOperations<String, String> operations = stringRedisTemplate.opsForValue();
+        operations.set(key, value, duration);
+    }
+
+    public void deleteData(String key) {
+        stringRedisTemplate.delete(key);
+    }
+
+    public void setBlackList(String key, Duration duration) {
+        ValueOperations<String, String> operations = blackListTemplate.opsForValue();
+        operations.set(key, "logout", duration);
+    }
+
+    public boolean hasBlackList(String key) {
+        return Boolean.TRUE.equals(blackListTemplate.hasKey(key));
+    }
+}

--- a/src/main/java/f4/auth/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/f4/auth/global/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,111 @@
+package f4.auth.global.security.jwt;
+
+
+import f4.auth.domain.user.dto.request.CreateTokenDto;
+import f4.auth.global.constant.CustomErrorCode;
+import f4.auth.global.redis.RedisService;
+import f4.auth.global.security.jwt.exception.ExpiredTokenException;
+import f4.auth.global.security.jwt.exception.InvalidTokenException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final RedisService redisService;
+
+    @Value("${jwt.secret}")
+    private String SECRET_KEY;
+
+    @Value("${jwt.token.access-expiration-time}")
+    private Long atkDuration;
+
+    @Value("${jwt.token.refresh-expiration-time}")
+    private Long rtkDuration;
+
+    @Value("${jwt.header}")
+    private String header;
+
+    @Value("${jwt.prefix}")
+    private String prefix;
+
+    private Key getSigningKey(String secretKey) {
+        byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String createAccessToken(CreateTokenDto createTokenDto) {
+        return createToken(createTokenDto, atkDuration);
+    }
+
+    public String createRefreshToken(CreateTokenDto createTokenDto) {
+        return createToken(createTokenDto, rtkDuration);
+    }
+
+    private String createToken(CreateTokenDto createTokenDto, long time) {
+        Claims claims = Jwts.claims();
+        claims.put("userId", createTokenDto.getId());
+        claims.put("username", createTokenDto.getUsername());
+        claims.put("email", createTokenDto.getEmail());
+
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setHeaderParam("typ", "JWT")
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + time))
+                .signWith(getSigningKey(SECRET_KEY), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public Claims extractAllClaims(String token) {
+//        if (redisService.hasBlackList(token)) {
+//            throw AlreadyLogoutException.EXCEPTION;
+//        }
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey(SECRET_KEY))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredTokenException(CustomErrorCode.EXPIRED_ACCESS_TOKEN);
+        } catch (InvalidTokenException e) {
+            throw new InvalidTokenException(CustomErrorCode.INVALID_ACCESS_TOKEN);
+        }
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader(header);
+        return parseToken(bearer);
+    }
+
+    public String parseToken(String bearerToken) {
+        if (bearerToken != null && bearerToken.startsWith(prefix)) {
+            return bearerToken.replace(prefix, "");
+        }
+        return null;
+    }
+
+    public Date getExpiredTime(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey(SECRET_KEY))
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getExpiration();
+    }
+}

--- a/src/main/java/f4/auth/global/security/jwt/JwtValidateService.java
+++ b/src/main/java/f4/auth/global/security/jwt/JwtValidateService.java
@@ -1,0 +1,27 @@
+package f4.auth.global.security.jwt;
+
+import f4.auth.global.constant.CustomErrorCode;
+import f4.auth.global.exception.CustomException;
+import f4.auth.global.redis.RedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JwtValidateService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RedisService redisService;
+
+
+    public String getEmail(String token) {
+        return jwtTokenProvider.extractAllClaims(token)
+                .get("email", String.class);
+    }
+
+    public void validateRefreshToken(String token) {
+        if (redisService.getData(getEmail(token)) == null) {
+            throw new CustomException(CustomErrorCode.INVALID_ACCESS_TOKEN);
+        }
+    }
+}

--- a/src/main/java/f4/auth/global/security/jwt/exception/ExpiredTokenException.java
+++ b/src/main/java/f4/auth/global/security/jwt/exception/ExpiredTokenException.java
@@ -1,0 +1,13 @@
+package f4.auth.global.security.jwt.exception;
+
+import f4.auth.global.constant.CustomErrorCode;
+import f4.auth.global.exception.CustomException;
+import lombok.Getter;
+
+@Getter
+public class ExpiredTokenException extends CustomException {
+
+    public ExpiredTokenException(CustomErrorCode customErrorCode) {
+        super(customErrorCode);
+    }
+}

--- a/src/main/java/f4/auth/global/security/jwt/exception/InvalidTokenException.java
+++ b/src/main/java/f4/auth/global/security/jwt/exception/InvalidTokenException.java
@@ -1,0 +1,13 @@
+package f4.auth.global.security.jwt.exception;
+
+import f4.auth.global.constant.CustomErrorCode;
+import f4.auth.global.exception.CustomException;
+import lombok.Getter;
+
+@Getter
+public class InvalidTokenException extends CustomException {
+
+    public InvalidTokenException(CustomErrorCode customErrorCode) {
+        super(customErrorCode);
+    }
+}

--- a/src/main/java/f4/auth/global/utils/Encryptor.java
+++ b/src/main/java/f4/auth/global/utils/Encryptor.java
@@ -31,4 +31,8 @@ public class Encryptor {
         }
         return builder.toString();
     }
+
+    public boolean matchers(String plain, String encrypted) {
+        return encrypt(plain).equals(encrypted);
+    }
 }


### PR DESCRIPTION
## 🧑🏻‍💻 구현 기능
로그인 시 AccessToken & RefreshToken을 생성하여 response에 반환해준다.
RefreshToken은 key값을 유저의 email로 지정하여 담아둔다. 
-> 추후 accessToken이 만료될 시 refreshToken이 있는 경우 accessToken을 재발급해주기 위함이다.

## 🤷🏻 동작 원리
1. 사용자로부터 로그인 정보를 입력 받는다.
2. 입력받은 정보로 DB에 접근하여 해당 유저 정보가 있는지 확인한다.
3. DB에 저장된 PW와 사용자가 입력한 PW 확인 후
4. AccessToken & RefreshToken을 발급하여 RefreshToken은 레디스에 저장 및 Response헤더에 토큰 정보를 담아 반환한다.

## ✍🏻 To do
- [x] JwtTokenProvider 
- [x] RedisConfig
- [x] RedisService 
- [x] Login-API 작성  

## 관련 이슈
- Closed #2 
