### PR TITLE
[user-service]feature/#6-get-user-info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ ext {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.modelmapper:modelmapper:2.4.2'

--- a/src/main/java/f4/auth/AuthApplication.java
+++ b/src/main/java/f4/auth/AuthApplication.java
@@ -3,9 +3,11 @@ package f4.auth;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableFeignClients
 public class AuthApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/f4/auth/domain/health/Controller/HealthController.java
+++ b/src/main/java/f4/auth/domain/health/Controller/HealthController.java
@@ -1,0 +1,14 @@
+package f4.auth.domain.health.Controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+
+  @GetMapping
+  public String getHealth() {
+
+    return  "It's Working in user-service";
+  }
+}

--- a/src/main/java/f4/auth/domain/user/controller/UserAdminController.java
+++ b/src/main/java/f4/auth/domain/user/controller/UserAdminController.java
@@ -1,0 +1,29 @@
+package f4.auth.domain.user.controller;
+
+import f4.auth.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserAdminController {
+
+  private final UserService userService;
+
+  /*
+   * @date : 2023.08.24
+   * @author : yuki
+   * @param : int page, value = [column]
+   * @description : 유저 전체 조회 - 페이징
+   */
+  @GetMapping("/admin/findAll")
+  public ResponseEntity<?> getUsers(
+      @RequestParam(required = false, defaultValue = "1", value = "page") int pageNo,
+      @RequestParam(required = false, defaultValue = "username", value = "criteria") String criteria
+  ) {
+    return ResponseEntity.ok(userService.getUsers(pageNo, criteria));
+  }
+}

--- a/src/main/java/f4/auth/domain/user/controller/UserAdminController.java
+++ b/src/main/java/f4/auth/domain/user/controller/UserAdminController.java
@@ -4,11 +4,13 @@ import f4.auth.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/admin/v1")
 public class UserAdminController {
 
   private final UserService userService;
@@ -19,7 +21,7 @@ public class UserAdminController {
    * @param : int page, value = [column]
    * @description : 유저 전체 조회 - 페이징
    */
-  @GetMapping("/admin/findAll")
+  @GetMapping("/findAll")
   public ResponseEntity<?> getUsers(
       @RequestParam(required = false, defaultValue = "1", value = "page") int pageNo,
       @RequestParam(required = false, defaultValue = "username", value = "criteria") String criteria

--- a/src/main/java/f4/auth/domain/user/controller/UserAdminController.java
+++ b/src/main/java/f4/auth/domain/user/controller/UserAdminController.java
@@ -1,10 +1,6 @@
 package f4.auth.domain.user.controller;
 
-import f4.auth.domain.user.dto.response.UserResponseDto;
 import f4.auth.domain.user.service.UserService;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,10 +26,6 @@ public class UserAdminController {
       @RequestParam(required = false, defaultValue = "1", value = "page") int pageNo,
       @RequestParam(required = false, defaultValue = "username", value = "criteria") String criteria
   ) {
-    Map<String, Object> data = new HashMap<>();
-    List<UserResponseDto> users = userService.getUsers(pageNo, criteria);
-    data.put("data", users);
-
-    return ResponseEntity.ok(data);
+    return ResponseEntity.ok(userService.getUsers(pageNo, criteria));
   }
 }

--- a/src/main/java/f4/auth/domain/user/controller/UserAdminController.java
+++ b/src/main/java/f4/auth/domain/user/controller/UserAdminController.java
@@ -1,6 +1,10 @@
 package f4.auth.domain.user.controller;
 
+import f4.auth.domain.user.dto.response.UserResponseDto;
 import f4.auth.domain.user.service.UserService;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,6 +30,10 @@ public class UserAdminController {
       @RequestParam(required = false, defaultValue = "1", value = "page") int pageNo,
       @RequestParam(required = false, defaultValue = "username", value = "criteria") String criteria
   ) {
-    return ResponseEntity.ok(userService.getUsers(pageNo, criteria));
+    Map<String, Object> data = new HashMap<>();
+    List<UserResponseDto> users = userService.getUsers(pageNo, criteria);
+    data.put("data", users);
+
+    return ResponseEntity.ok(data);
   }
 }

--- a/src/main/java/f4/auth/domain/user/controller/UserController.java
+++ b/src/main/java/f4/auth/domain/user/controller/UserController.java
@@ -2,7 +2,10 @@ package f4.auth.domain.user.controller;
 
 import f4.auth.domain.user.dto.request.SignupRequestDto;
 import f4.auth.domain.user.dto.response.MailingResponseDto;
+import f4.auth.domain.user.dto.response.UserResponseDto;
 import f4.auth.domain.user.service.UserService;
+import java.util.HashMap;
+import java.util.Map;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,14 +38,18 @@ public class UserController {
   }
 
   /*
-  * @date : 2023.08.26
-  * @author : yuki
-  * @param : userId
-  * @description : 회원 상세 정보
-  */
+   * @date : 2023.08.26
+   * @author : yuki
+   * @param : userId
+   * @description : 회원 상세 정보
+   */
   @GetMapping("/detail/{userId}")
-  public ResponseEntity<?> getUserByUserId(@PathVariable("userId") Long userId){
-    return ResponseEntity.ok(userService.getUser(userId));
+  public ResponseEntity<?> getUserByUserId(@PathVariable("userId") Long userId) {
+    UserResponseDto response = userService.getUser(userId);
+    Map<String, Object> data = new HashMap<>();
+    data.put("data", response);
+
+    return ResponseEntity.ok(data);
   }
 
   /*

--- a/src/main/java/f4/auth/domain/user/controller/UserController.java
+++ b/src/main/java/f4/auth/domain/user/controller/UserController.java
@@ -35,10 +35,21 @@ public class UserController {
   }
 
   /*
+  * @date : 2023.08.26
+  * @author : yuki
+  * @param : userId
+  * @description : 회원 상세 정보
+  */
+  @GetMapping("/detail/{userId}")
+  public ResponseEntity<?> getUserByUserId(@PathVariable("userId") Long userId){
+    return ResponseEntity.ok(userService.getUser(userId));
+  }
+
+  /*
    * @date : 2023.08.24
    * @author : yuki
    * @param : userId
-   * @description : email-service 해당 유저의 이메일 정보 조회
+   * @description : email-service 해당 id 유저의 이메일 정보 조회
    * */
   @GetMapping("/email/{userId}")
   public MailingResponseDto getUserByUserIdForMailing(@PathVariable("userId") Long userId) {

--- a/src/main/java/f4/auth/domain/user/controller/UserController.java
+++ b/src/main/java/f4/auth/domain/user/controller/UserController.java
@@ -1,12 +1,14 @@
 package f4.auth.domain.user.controller;
 
 import f4.auth.domain.user.dto.request.SignupRequestDto;
+import f4.auth.domain.user.dto.response.MailingResponseDto;
 import f4.auth.domain.user.persist.repository.UserRepository;
 import f4.auth.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,7 +19,7 @@ import javax.validation.Valid;
 @RestController
 @Slf4j
 @RequiredArgsConstructor
-@RequestMapping("/auth/v1")
+@RequestMapping("/user/v1")
 public class UserController {
 
   private final UserService userService;
@@ -28,8 +30,19 @@ public class UserController {
   }
 
   @PostMapping("/signup")
-  public ResponseEntity<String> register(@Valid @RequestBody SignupRequestDto signupRequestDto) {
+  public ResponseEntity<?> register(@Valid @RequestBody SignupRequestDto signupRequestDto) {
     userService.register(signupRequestDto);
     return ResponseEntity.ok("회원가입에 성공하였습니다.");
+  }
+
+  /*
+   * @date : 2023.08.24
+   * @author : yuki
+   * @param : userId
+   * @description : email-service 해당 유저의 이메일 정보 조회
+   * */
+  @GetMapping("/email/{userId}")
+  public MailingResponseDto getUserNyUserIdForMailing(@PathVariable("userId") Long userId) {
+    return userService.getUserByUserIdForMailing(userId);
   }
 }

--- a/src/main/java/f4/auth/domain/user/controller/UserController.java
+++ b/src/main/java/f4/auth/domain/user/controller/UserController.java
@@ -12,7 +12,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -24,11 +23,11 @@ public class UserController {
   private final UserService userService;
 
   /*
-  * @date : 2023.08.22
-  * @author : yuki
-  * @param : RequestDto
-  * @description : 회원 등록
-  */
+   * @date : 2023.08.22
+   * @author : yuki
+   * @param : RequestDto
+   * @description : 회원 등록
+   */
   @PostMapping("/signup")
   public ResponseEntity<?> register(@Valid @RequestBody SignupRequestDto signupRequestDto) {
     userService.register(signupRequestDto);

--- a/src/main/java/f4/auth/domain/user/controller/UserController.java
+++ b/src/main/java/f4/auth/domain/user/controller/UserController.java
@@ -2,8 +2,8 @@ package f4.auth.domain.user.controller;
 
 import f4.auth.domain.user.dto.request.SignupRequestDto;
 import f4.auth.domain.user.dto.response.MailingResponseDto;
-import f4.auth.domain.user.persist.repository.UserRepository;
 import f4.auth.domain.user.service.UserService;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -12,9 +12,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.validation.Valid;
 
 @RestController
 @Slf4j
@@ -24,11 +23,12 @@ public class UserController {
 
   private final UserService userService;
 
-  @GetMapping("/health-check")
-  public String status() {
-    return "It's Working in Auth-Service";
-  }
-
+  /*
+  * @date : 2023.08.22
+  * @author : yuki
+  * @param : RequestDto
+  * @description : 회원 등록
+  */
   @PostMapping("/signup")
   public ResponseEntity<?> register(@Valid @RequestBody SignupRequestDto signupRequestDto) {
     userService.register(signupRequestDto);
@@ -42,7 +42,7 @@ public class UserController {
    * @description : email-service 해당 유저의 이메일 정보 조회
    * */
   @GetMapping("/email/{userId}")
-  public MailingResponseDto getUserNyUserIdForMailing(@PathVariable("userId") Long userId) {
+  public MailingResponseDto getUserByUserIdForMailing(@PathVariable("userId") Long userId) {
     return userService.getUserByUserIdForMailing(userId);
   }
 }

--- a/src/main/java/f4/auth/domain/user/controller/UserController.java
+++ b/src/main/java/f4/auth/domain/user/controller/UserController.java
@@ -2,10 +2,7 @@ package f4.auth.domain.user.controller;
 
 import f4.auth.domain.user.dto.request.SignupRequestDto;
 import f4.auth.domain.user.dto.response.MailingResponseDto;
-import f4.auth.domain.user.dto.response.UserResponseDto;
 import f4.auth.domain.user.service.UserService;
-import java.util.HashMap;
-import java.util.Map;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -45,11 +42,7 @@ public class UserController {
    */
   @GetMapping("/detail/{userId}")
   public ResponseEntity<?> getUserByUserId(@PathVariable("userId") Long userId) {
-    UserResponseDto response = userService.getUser(userId);
-    Map<String, Object> data = new HashMap<>();
-    data.put("data", response);
-
-    return ResponseEntity.ok(data);
+    return ResponseEntity.ok(userService.getUser(userId));
   }
 
   /*

--- a/src/main/java/f4/auth/domain/user/dto/response/MailingResponseDto.java
+++ b/src/main/java/f4/auth/domain/user/dto/response/MailingResponseDto.java
@@ -1,0 +1,16 @@
+package f4.auth.domain.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class MailingResponseDto {
+
+  private String username;
+  private String email;
+}

--- a/src/main/java/f4/auth/domain/user/dto/response/UserResponseDto.java
+++ b/src/main/java/f4/auth/domain/user/dto/response/UserResponseDto.java
@@ -1,0 +1,37 @@
+package f4.auth.domain.user.dto.response;
+
+import f4.auth.domain.user.persist.entity.User;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserResponseDto {
+
+  private String username;
+  private String gender;
+  private String birth;
+  private String address;
+  private String email;
+  private String phoneNumber;
+  private LocalDateTime createdAt;
+  private LocalDateTime updateAt;
+
+  public static UserResponseDto toDto(final User user) {
+    return UserResponseDto.builder()
+        .username(user.getUsername())
+        .gender(user.getGender())
+        .birth(user.getBirth())
+        .address(user.getAddress())
+        .email(user.getEmail())
+        .phoneNumber(user.getPhoneNumber())
+        .createdAt(user.getCreatedAt())
+        .updateAt(user.getUpdatedAt())
+        .build();
+  }
+}

--- a/src/main/java/f4/auth/domain/user/dto/response/UserResponseDto.java
+++ b/src/main/java/f4/auth/domain/user/dto/response/UserResponseDto.java
@@ -13,6 +13,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class UserResponseDto {
 
+  private Long userId;
   private String username;
   private String gender;
   private String birth;
@@ -24,6 +25,7 @@ public class UserResponseDto {
 
   public static UserResponseDto toDto(final User user) {
     return UserResponseDto.builder()
+        .userId(user.getId())
         .username(user.getUsername())
         .gender(user.getGender())
         .birth(user.getBirth())

--- a/src/main/java/f4/auth/domain/user/persist/repository/UserRepository.java
+++ b/src/main/java/f4/auth/domain/user/persist/repository/UserRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByEmail(String email);
+
+  Optional<User> findById(Long id);
 }

--- a/src/main/java/f4/auth/domain/user/persist/repository/UserRepository.java
+++ b/src/main/java/f4/auth/domain/user/persist/repository/UserRepository.java
@@ -1,10 +1,11 @@
 package f4.auth.domain.user.persist.repository;
 
 import f4.auth.domain.user.persist.entity.User;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -12,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByEmail(String email);
 
   Optional<User> findById(Long id);
+
+  Page<User> findAll(Pageable pageable);
 }

--- a/src/main/java/f4/auth/domain/user/persist/repository/UserRepository.java
+++ b/src/main/java/f4/auth/domain/user/persist/repository/UserRepository.java
@@ -10,9 +10,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-  Optional<User> findByEmail(String email);
-
   Optional<User> findById(Long id);
+
+  Optional<User> findByEmail(String email);
 
   Page<User> findAll(Pageable pageable);
 }

--- a/src/main/java/f4/auth/domain/user/service/UserService.java
+++ b/src/main/java/f4/auth/domain/user/service/UserService.java
@@ -1,8 +1,11 @@
 package f4.auth.domain.user.service;
 
 import f4.auth.domain.user.dto.request.SignupRequestDto;
+import f4.auth.domain.user.dto.response.MailingResponseDto;
 
 public interface UserService {
 
   void register(SignupRequestDto signupRequestDto);
+
+  MailingResponseDto getUserByUserIdForMailing(Long userId);
 }

--- a/src/main/java/f4/auth/domain/user/service/UserService.java
+++ b/src/main/java/f4/auth/domain/user/service/UserService.java
@@ -2,10 +2,14 @@ package f4.auth.domain.user.service;
 
 import f4.auth.domain.user.dto.request.SignupRequestDto;
 import f4.auth.domain.user.dto.response.MailingResponseDto;
+import f4.auth.domain.user.dto.response.UserResponseDto;
+import java.util.List;
 
 public interface UserService {
 
   void register(SignupRequestDto signupRequestDto);
 
   MailingResponseDto getUserByUserIdForMailing(Long userId);
+
+  List<UserResponseDto> getUsers(int pageNo, String criteria);
 }

--- a/src/main/java/f4/auth/domain/user/service/UserService.java
+++ b/src/main/java/f4/auth/domain/user/service/UserService.java
@@ -4,12 +4,15 @@ import f4.auth.domain.user.dto.request.SignupRequestDto;
 import f4.auth.domain.user.dto.response.MailingResponseDto;
 import f4.auth.domain.user.dto.response.UserResponseDto;
 import java.util.List;
+import org.springframework.http.ResponseEntity;
 
 public interface UserService {
 
   void register(SignupRequestDto signupRequestDto);
 
   MailingResponseDto getUserByUserIdForMailing(Long userId);
+
+  UserResponseDto getUser(Long userId);
 
   List<UserResponseDto> getUsers(int pageNo, String criteria);
 }

--- a/src/main/java/f4/auth/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/f4/auth/domain/user/service/impl/UserServiceImpl.java
@@ -4,6 +4,7 @@ import static f4.auth.domain.user.constant.Role.USER;
 
 import f4.auth.domain.user.dto.request.SignupRequestDto;
 import f4.auth.domain.user.dto.response.MailingResponseDto;
+import f4.auth.domain.user.dto.response.UserResponseDto;
 import f4.auth.domain.user.persist.entity.User;
 import f4.auth.domain.user.persist.repository.UserRepository;
 import f4.auth.domain.user.service.UserService;
@@ -11,8 +12,13 @@ import f4.auth.global.constant.CustomErrorCode;
 import f4.auth.global.exception.CustomException;
 import f4.auth.global.utils.Encryptor;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -22,6 +28,7 @@ public class UserServiceImpl implements UserService {
   private final UserRepository userRepository;
   private final ModelMapper modelMapper;
   private final Encryptor crypto;
+  private static final int PAGE_SIZE = 10;
 
   @Override
   public void register(SignupRequestDto signupRequestDto) {
@@ -60,6 +67,14 @@ public class UserServiceImpl implements UserService {
         .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_USER));
 
     return modelMapper.map(user, MailingResponseDto.class);
+  }
+
+  @Override
+  public List<UserResponseDto> getUsers(int pageNo, String criteria) {
+    Pageable pageable = PageRequest.of(pageNo - 1, PAGE_SIZE, Sort.by(Direction.ASC, criteria));
+
+    return userRepository.findAll(pageable).getContent().stream().map(UserResponseDto::toDto)
+        .toList();
   }
 }
 

--- a/src/main/java/f4/auth/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/f4/auth/domain/user/service/impl/UserServiceImpl.java
@@ -1,24 +1,26 @@
 package f4.auth.domain.user.service.impl;
 
+import static f4.auth.domain.user.constant.Role.USER;
+
 import f4.auth.domain.user.dto.request.SignupRequestDto;
+import f4.auth.domain.user.dto.response.MailingResponseDto;
 import f4.auth.domain.user.persist.entity.User;
 import f4.auth.domain.user.persist.repository.UserRepository;
 import f4.auth.domain.user.service.UserService;
 import f4.auth.global.constant.CustomErrorCode;
 import f4.auth.global.exception.CustomException;
 import f4.auth.global.utils.Encryptor;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.time.LocalDateTime;
-
-import static f4.auth.domain.user.constant.Role.USER;
+import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
   private final UserRepository userRepository;
+  private final ModelMapper modelMapper;
   private final Encryptor crypto;
 
   @Override
@@ -51,4 +53,14 @@ public class UserServiceImpl implements UserService {
               throw new CustomException(CustomErrorCode.ALREADY_REGISTERED_MEMBER);
             });
   }
+
+  @Override
+  public MailingResponseDto getUserByUserIdForMailing(Long userId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_USER));
+
+    return modelMapper.map(user, MailingResponseDto.class);
+  }
 }
+
+

--- a/src/main/java/f4/auth/domain/user/service/impl/UserServiceImpl.java
+++ b/src/main/java/f4/auth/domain/user/service/impl/UserServiceImpl.java
@@ -61,19 +61,33 @@ public class UserServiceImpl implements UserService {
             });
   }
 
+  // userId로 유저 정보 조회
+  @Override
+  public UserResponseDto getUser(Long userId) {
+    User user = getUserFindById(userId);
+    return modelMapper.map(user, UserResponseDto.class);
+  }
+
+  // mail-service 에서 필요한 정보 userId로 조회
   @Override
   public MailingResponseDto getUserByUserIdForMailing(Long userId) {
-    User user = userRepository.findById(userId)
-        .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_USER));
-
+    User user = getUserFindById(userId);
     return modelMapper.map(user, MailingResponseDto.class);
+  }
+
+  // admin 유저 전체 정보 조회
+  private User getUserFindById(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_USER));
   }
 
   @Override
   public List<UserResponseDto> getUsers(int pageNo, String criteria) {
     Pageable pageable = PageRequest.of(pageNo - 1, PAGE_SIZE, Sort.by(Direction.ASC, criteria));
 
-    return userRepository.findAll(pageable).getContent().stream().map(UserResponseDto::toDto)
+    return userRepository.findAll(pageable)
+        .getContent().stream()
+        .map(UserResponseDto::toDto)
         .toList();
   }
 }

--- a/src/main/java/f4/auth/global/constant/CustomErrorCode.java
+++ b/src/main/java/f4/auth/global/constant/CustomErrorCode.java
@@ -22,7 +22,7 @@ public enum CustomErrorCode {
   // Forbidden 402
 
   // Not Found 404
-  NOT_FOUND_MEMBER("/user/v1/login", 404, "해당 회원을 찾을 수 없습니다.");
+  NOT_FOUND_USER("/user/v1/login", 404, "해당 회원을 찾을 수 없습니다.");
 
   private final String path;
   private final int code;


### PR DESCRIPTION
## 🧑🏻‍💻 구현 기능
회원 정보 조회 요청 API를 구현한다.

## 🤷🏻 동작 원리
1. OpenFeign으로 API 호출되면 해당 정보를 반환한다.

## ✍🏻 세부 작업 내용
- [x] : 회원 상세 정보
- [x] : 관리자 모드 모든 회원 정보 요청  
- [x] : email-scheduler에서 필요한 회원 이름 및 이메일 정보 요청 API

## 💡 관련 이슈
- Closed #8 