### PR TITLE
[user-service]feature/#8-reissue-and-logout

### DIFF
--- a/src/main/java/f4/auth/domain/auth/controller/AuthController.java
+++ b/src/main/java/f4/auth/domain/auth/controller/AuthController.java
@@ -3,12 +3,16 @@ package f4.auth.domain.auth.controller;
 import f4.auth.domain.auth.dtto.request.LoginRequestDto;
 import f4.auth.domain.auth.dtto.response.TokenResponseDto;
 import f4.auth.domain.auth.service.AuthService;
+import f4.auth.global.utils.CookieProvider;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,20 +21,30 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth/v1")
-@CrossOrigin({"http://localhost:4000", "http://localhost:8892"})
 public class AuthController {
 
   private final AuthService authService;
+  private final CookieProvider cookieProvider;
 
   @PostMapping("/login")
   public ResponseEntity<?> login(@Valid @RequestBody LoginRequestDto loginRequestDto) {
     TokenResponseDto responseDto = authService.login(loginRequestDto);
 
+    ResponseCookie responseCookie = cookieProvider.createRefreshTokenCookie(responseDto.getRefreshToken());
+
     HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
     headers.add("Authorization", responseDto.getGrantType() + responseDto.getAccessToken());
-    headers.add("refresh-token", responseDto.getRefreshToken());
+
 
     return ResponseEntity.status(HttpStatus.OK)
-        .headers(headers).body("로그인에 성공하셨습니다.");
+        .headers(headers)
+        .header(HttpHeaders.COOKIE, responseCookie.toString())
+        .body("로그인에 성공하셨습니다.");
+  }
+
+  @GetMapping("/request")
+  public String request(HttpServletRequest request) {
+    return "request 성공 : " + request.getHeader("Authorization") + request.getHeader("Role") + request.getHeader("userId");
   }
 }

--- a/src/main/java/f4/auth/domain/auth/controller/AuthController.java
+++ b/src/main/java/f4/auth/domain/auth/controller/AuthController.java
@@ -1,7 +1,7 @@
 package f4.auth.domain.auth.controller;
 
-import f4.auth.domain.auth.dtto.request.LoginRequestDto;
-import f4.auth.domain.auth.dtto.response.TokenResponseDto;
+import f4.auth.domain.auth.dto.request.LoginRequestDto;
+import f4.auth.domain.auth.dto.response.TokenResponseDto;
 import f4.auth.domain.auth.service.AuthService;
 import f4.auth.global.utils.CookieProvider;
 import javax.servlet.http.HttpServletRequest;
@@ -12,9 +12,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,15 +29,17 @@ public class AuthController {
   private final CookieProvider cookieProvider;
 
   @PostMapping("/login")
-  public ResponseEntity<?> login(@Valid @RequestBody LoginRequestDto loginRequestDto) {
+  public ResponseEntity<?> login(
+      @Valid @RequestBody LoginRequestDto loginRequestDto) {
+
     TokenResponseDto responseDto = authService.login(loginRequestDto);
 
-    ResponseCookie responseCookie = cookieProvider.createRefreshTokenCookie(responseDto.getRefreshToken());
+    ResponseCookie responseCookie = cookieProvider.createRefreshTokenCookie(
+        responseDto.getRefreshToken());
 
     HttpHeaders headers = new HttpHeaders();
     headers.setContentType(MediaType.APPLICATION_JSON);
     headers.add("Authorization", responseDto.getGrantType() + responseDto.getAccessToken());
-
 
     return ResponseEntity.status(HttpStatus.OK)
         .headers(headers)
@@ -43,8 +47,24 @@ public class AuthController {
         .body("로그인에 성공하셨습니다.");
   }
 
+  @PostMapping("/token/reissue")
+  public ResponseEntity<?> reissue(
+      @RequestHeader("Authorization") String accessToken,
+      @CookieValue("refresh-token") String refreshToken) {
+    TokenResponseDto responseDto = authService.reissue(refreshToken);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    headers.add("Authorization", responseDto.getGrantType() + responseDto.getAccessToken());
+
+    return ResponseEntity.status(HttpStatus.OK)
+        .headers(headers)
+        .body("토큰이 재발행 되었습니다.");
+  }
+
   @GetMapping("/request")
   public String request(HttpServletRequest request) {
-    return "request 성공 : " + request.getHeader("Authorization") + request.getHeader("Role") + request.getHeader("userId");
+    return "request 성공 : " + request.getHeader("Authorization") + request.getHeader("Role")
+        + request.getHeader("userId");
   }
 }

--- a/src/main/java/f4/auth/domain/auth/controller/AuthController.java
+++ b/src/main/java/f4/auth/domain/auth/controller/AuthController.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -62,9 +63,11 @@ public class AuthController {
         .body("토큰이 재발행 되었습니다.");
   }
 
-  @GetMapping("/request")
-  public String request(HttpServletRequest request) {
-    return "request 성공 : " + request.getHeader("Authorization") + request.getHeader("Role")
-        + request.getHeader("userId");
+  @PatchMapping("/logout")
+  public ResponseEntity<?> logout(
+      @RequestHeader("Authorization") String accessToken) {
+
+    authService.logout(accessToken);
+    return ResponseEntity.status(HttpStatus.OK).body("로그아웃에 성공하셨습니다.");
   }
 }

--- a/src/main/java/f4/auth/domain/auth/dto/CreateTokenDto.java
+++ b/src/main/java/f4/auth/domain/auth/dto/CreateTokenDto.java
@@ -1,4 +1,4 @@
-package f4.auth.domain.auth.dtto;
+package f4.auth.domain.auth.dto;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;

--- a/src/main/java/f4/auth/domain/auth/dto/request/LoginRequestDto.java
+++ b/src/main/java/f4/auth/domain/auth/dto/request/LoginRequestDto.java
@@ -1,4 +1,4 @@
-package f4.auth.domain.auth.dtto.request;
+package f4.auth.domain.auth.dto.request;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;

--- a/src/main/java/f4/auth/domain/auth/dto/response/TokenResponseDto.java
+++ b/src/main/java/f4/auth/domain/auth/dto/response/TokenResponseDto.java
@@ -1,4 +1,4 @@
-package f4.auth.domain.auth.dtto.response;
+package f4.auth.domain.auth.dto.response;
 
 
 import lombok.Builder;

--- a/src/main/java/f4/auth/domain/auth/dtto/CreateTokenDto.java
+++ b/src/main/java/f4/auth/domain/auth/dtto/CreateTokenDto.java
@@ -16,6 +16,7 @@ public class CreateTokenDto {
 
   private Long id;
   private String role;
+  private String email;
 }
 
 

--- a/src/main/java/f4/auth/domain/auth/service/AuthService.java
+++ b/src/main/java/f4/auth/domain/auth/service/AuthService.java
@@ -7,4 +7,5 @@ public interface AuthService {
 
   TokenResponseDto login(LoginRequestDto loginRequestDto);
   TokenResponseDto reissue(String refreshToken);
+  void logout(String accessToken);
 }

--- a/src/main/java/f4/auth/domain/auth/service/AuthService.java
+++ b/src/main/java/f4/auth/domain/auth/service/AuthService.java
@@ -1,9 +1,10 @@
 package f4.auth.domain.auth.service;
 
-import f4.auth.domain.auth.dtto.request.LoginRequestDto;
-import f4.auth.domain.auth.dtto.response.TokenResponseDto;
+import f4.auth.domain.auth.dto.request.LoginRequestDto;
+import f4.auth.domain.auth.dto.response.TokenResponseDto;
 
 public interface AuthService {
 
   TokenResponseDto login(LoginRequestDto loginRequestDto);
+  TokenResponseDto reissue(String refreshToken);
 }

--- a/src/main/java/f4/auth/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/f4/auth/domain/auth/service/impl/AuthServiceImpl.java
@@ -46,7 +46,7 @@ public class AuthServiceImpl implements AuthService {
     final String atk = jwtTokenProvider.createAccessToken(createTokenDto);
     final String rtk = jwtTokenProvider.createRefreshToken(createTokenDto);
 
-    redisService.setDataExpire(loginRequestDto.getEmail(), rtk, Duration.ofMillis(rtkDuration));
+    redisService.setDataExpire(createTokenDto.getEmail(), rtk, Duration.ofMillis(rtkDuration));
 
     return TokenResponseDto.builder()
         .accessToken(atk)

--- a/src/main/java/f4/auth/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/f4/auth/domain/auth/service/impl/AuthServiceImpl.java
@@ -1,8 +1,8 @@
 package f4.auth.domain.auth.service.impl;
 
-import f4.auth.domain.auth.dtto.CreateTokenDto;
-import f4.auth.domain.auth.dtto.request.LoginRequestDto;
-import f4.auth.domain.auth.dtto.response.TokenResponseDto;
+import f4.auth.domain.auth.dto.CreateTokenDto;
+import f4.auth.domain.auth.dto.request.LoginRequestDto;
+import f4.auth.domain.auth.dto.response.TokenResponseDto;
 import f4.auth.domain.auth.service.AuthService;
 import f4.auth.domain.user.persist.entity.User;
 import f4.auth.domain.user.persist.repository.UserRepository;
@@ -34,8 +34,7 @@ public class AuthServiceImpl implements AuthService {
   @Override
   @Transactional
   public TokenResponseDto login(LoginRequestDto loginRequestDto) {
-    User user = userRepository.findByEmail(loginRequestDto.getEmail())
-        .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_USER));
+    User user = loadByEmail(loginRequestDto.getEmail());
 
     if (!encryptor.matchers(loginRequestDto.getPassword(), user.getPassword())) {
       throw new CustomException(CustomErrorCode.NOT_VALID_LOGIN_PASSWORD);
@@ -52,5 +51,30 @@ public class AuthServiceImpl implements AuthService {
         .accessToken(atk)
         .refreshToken(rtk)
         .build();
+  }
+
+
+  @Override
+  public TokenResponseDto reissue(String refreshToken) {
+    String email = jwtTokenProvider.extractAllClaims(refreshToken).getSubject();
+
+    if (!redisService.hasBlackList(email) && refreshToken.equals(redisService.getData(email))) {
+      throw new CustomException(CustomErrorCode.ALREADY_LOGOUT_USER);
+    }
+
+    User user = loadByEmail(email);
+
+    CreateTokenDto createTokenDto = modelMapper.map(user, CreateTokenDto.class);
+    final String atk = jwtTokenProvider.createAccessToken(createTokenDto);
+
+    return TokenResponseDto.builder()
+        .accessToken(atk)
+        .build();
+
+  }
+
+  private User loadByEmail(String loginRequestDto) {
+    return userRepository.findByEmail(loginRequestDto)
+        .orElseThrow(() -> new CustomException(CustomErrorCode.NOT_FOUND_USER));
   }
 }

--- a/src/main/java/f4/auth/global/constant/CustomErrorCode.java
+++ b/src/main/java/f4/auth/global/constant/CustomErrorCode.java
@@ -9,11 +9,13 @@ public enum CustomErrorCode {
 
   // Bad Request 400
   ALREADY_REGISTERED_MEMBER("/user/v1/signup", 400, "이미 회원 가입한 계정이 존재합니다."),
+  ALREADY_LOGOUT_USER("/auth/v1/token/reissue" ,400, "이미 로그아웃된 유저입니다."),
   CAN_NOT_ENCRYPT("/user/v1/signup", 400, "비밀번호를 암호화 할 수 없습니다."),
   NOT_VALID_LOGIN_PASSWORD("/user/v1/login", 400, "비밀번호가 틀렸습니다."),
 
   // Unathorized 401
   INVALID_ACCESS_TOKEN("user/v1/login", 401, "잘못된 토큰 입니다"),
+  INVALID_REFRESH_TOKEN("user/v1/reIssue", 401, "잘못된 토큰 입니다"),
   UNSUPPORTED_TOKEN("user/v1/login", 401, "지원하지 않는 토큰입니다"),
   EXPIRED_ACCESS_TOKEN("user/v1/login", 401, "만료된 엑세스토큰 입니다"),
   EXPIRED_REFRESH_TOKEN("user/v1/login", 401, "만료된 리프레시토큰 입니다"),

--- a/src/main/java/f4/auth/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/f4/auth/global/security/jwt/JwtTokenProvider.java
@@ -1,7 +1,12 @@
 package f4.auth.global.security.jwt;
 
-import f4.auth.domain.auth.dtto.CreateTokenDto;
+import f4.auth.domain.auth.dto.CreateTokenDto;
+import f4.auth.global.constant.CustomErrorCode;
+import f4.auth.global.exception.CustomException;
+import f4.auth.global.security.jwt.exception.ExpiredTokenException;
+import f4.auth.global.security.jwt.exception.InvalidTokenException;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -10,9 +15,11 @@ import java.security.Key;
 import java.util.Date;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtTokenProvider {
@@ -25,9 +32,6 @@ public class JwtTokenProvider {
 
   @Value("${jwt.token.refresh-token-duration}")
   private Long rtkDuration;
-
-  @Value("${jwt.token.header}")
-  private String header;
 
   private Key getSigningKey(String secretKey) {
     byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
@@ -44,6 +48,7 @@ public class JwtTokenProvider {
     return Jwts.builder()
         .setHeaderParam("typ", "JWT")
         .setClaims(claims)
+        .setSubject(createTokenDto.getEmail())
         .setIssuedAt(now)
         .setExpiration(new Date(now.getTime() + atkDuration))
         .signWith(getSigningKey(SECRET_KEY), SignatureAlgorithm.HS512)
@@ -64,5 +69,21 @@ public class JwtTokenProvider {
         .setExpiration(new Date(now.getTime() + rtkDuration))
         .signWith(getSigningKey(SECRET_KEY), SignatureAlgorithm.HS512)
         .compact();
+  }
+
+  public Claims extractAllClaims(String token) {
+    try {
+      return Jwts.parserBuilder()
+          .setSigningKey(getSigningKey(SECRET_KEY))
+          .build()
+          .parseClaimsJws(token)
+          .getBody();
+    } catch (ExpiredJwtException e) {
+      throw new ExpiredTokenException(CustomErrorCode.EXPIRED_ACCESS_TOKEN);
+    } catch (InvalidTokenException e) {
+      throw new InvalidTokenException(CustomErrorCode.INVALID_ACCESS_TOKEN);
+    } catch(Exception e){
+      throw new CustomException(CustomErrorCode.INVALID_REFRESH_TOKEN);
+    }
   }
 }

--- a/src/main/java/f4/auth/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/f4/auth/global/security/jwt/JwtTokenProvider.java
@@ -33,6 +33,9 @@ public class JwtTokenProvider {
   @Value("${jwt.token.refresh-token-duration}")
   private Long rtkDuration;
 
+  @Value("${jwt.prefix}")
+  private String prefix;
+
   private Key getSigningKey(String secretKey) {
     byte[] keyBytes = secretKey.getBytes(StandardCharsets.UTF_8);
     return Keys.hmacShaKeyFor(keyBytes);
@@ -71,6 +74,13 @@ public class JwtTokenProvider {
         .compact();
   }
 
+  public String parseToken(String bearerToken) {
+    if (bearerToken != null && bearerToken.startsWith(prefix)) {
+      return bearerToken.replace(prefix, "");
+    }
+    return null;
+  }
+
   public Claims extractAllClaims(String token) {
     try {
       return Jwts.parserBuilder()
@@ -82,7 +92,7 @@ public class JwtTokenProvider {
       throw new ExpiredTokenException(CustomErrorCode.EXPIRED_ACCESS_TOKEN);
     } catch (InvalidTokenException e) {
       throw new InvalidTokenException(CustomErrorCode.INVALID_ACCESS_TOKEN);
-    } catch(Exception e){
+    } catch (Exception e) {
       throw new CustomException(CustomErrorCode.INVALID_REFRESH_TOKEN);
     }
   }

--- a/src/main/java/f4/auth/global/security/jwt/exception/AlreadyLogoutException.java
+++ b/src/main/java/f4/auth/global/security/jwt/exception/AlreadyLogoutException.java
@@ -1,0 +1,14 @@
+package f4.auth.global.security.jwt.exception;
+
+
+import f4.auth.global.constant.CustomErrorCode;
+import f4.auth.global.exception.CustomException;
+import lombok.Getter;
+
+@Getter
+public class AlreadyLogoutException extends CustomException {
+
+  public AlreadyLogoutException(CustomErrorCode customErrorCode) {
+    super(customErrorCode);
+  }
+}

--- a/src/main/java/f4/auth/global/security/jwt/exception/ExpiredTokenException.java
+++ b/src/main/java/f4/auth/global/security/jwt/exception/ExpiredTokenException.java
@@ -1,0 +1,13 @@
+package f4.auth.global.security.jwt.exception;
+
+import f4.auth.global.constant.CustomErrorCode;
+import f4.auth.global.exception.CustomException;
+import lombok.Getter;
+
+@Getter
+public class ExpiredTokenException extends CustomException {
+
+  public ExpiredTokenException(CustomErrorCode customErrorCode) {
+    super(customErrorCode);
+  }
+}

--- a/src/main/java/f4/auth/global/security/jwt/exception/InvalidTokenException.java
+++ b/src/main/java/f4/auth/global/security/jwt/exception/InvalidTokenException.java
@@ -1,0 +1,14 @@
+package f4.auth.global.security.jwt.exception;
+
+
+import f4.auth.global.constant.CustomErrorCode;
+import f4.auth.global.exception.CustomException;
+import lombok.Getter;
+
+@Getter
+public class InvalidTokenException extends CustomException {
+
+  public InvalidTokenException(CustomErrorCode customErrorCode) {
+    super(customErrorCode);
+  }
+}

--- a/src/main/java/f4/auth/global/utils/CookieProvider.java
+++ b/src/main/java/f4/auth/global/utils/CookieProvider.java
@@ -1,0 +1,37 @@
+package f4.auth.global.utils;
+
+import javax.servlet.http.Cookie;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieProvider {
+
+  @Value("${jwt.token.refresh-token-duration}")
+  private String refreshTokenExpiredTime;
+
+  public ResponseCookie createRefreshTokenCookie(String refreshToken) {
+    return ResponseCookie.from("refresh-token", refreshToken)
+        .httpOnly(true)
+        .secure(false)
+        .path("/")
+        .maxAge(Long.parseLong(refreshTokenExpiredTime)).build();
+  }
+
+  public ResponseCookie removeRefreshTokenCookie() {
+    return ResponseCookie.from("refresh-token", null)
+        .maxAge(0)
+        .path("/")
+        .build();
+  }
+
+  public Cookie of(ResponseCookie responseCookie) {
+    Cookie cookie = new Cookie(responseCookie.getName(), responseCookie.getValue());
+    cookie.setPath(responseCookie.getPath());
+    cookie.setSecure(responseCookie.isSecure());
+    cookie.setHttpOnly(responseCookie.isHttpOnly());
+    cookie.setMaxAge((int) responseCookie.getMaxAge().getSeconds());
+    return cookie;
+  }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 구현 기능
클라이언트 측에서 Cookie에 Refresh Token을 보내면 해당 Refresh Token 정보 추출 및 검증 후 새로운 Access Token을 발급한다.
로그아웃의 경우 Access Token에서 레디스 키값(이메일)을 추출하여 삭제하고, Access Token을 키값으로 할당하여 Access Token에 유효시간까지 레디스 내에 벤을 시켜둔다.

## 🤷🏻 동작 원리
**재발급**
1. access token이 만료될 상태일 경우, 클라이언트  측에서 reissue 요청을 보낸다.
2. 쿠키에 담겨진 refresh-token추출 및 검증 후 새로운 access token을 발급한다.

**로그아웃**
1. access token에서 정보를 추출하여 기존 레디스의 등록된 refresh token을 삭제해준다.
2. access token의 유효 시간만큼 레디스의 해당 access token을 블랙리스트 등록한다.

## ✍🏻 To do
- [x] reIssue API 작성
- [x] logout API 작성 

## 관련 이슈
- Closed #18  
