### PR TITLE
[user-service]feature/#9-email-certification

### DIFF
--- a/src/main/java/f4/auth/domain/auth/controller/AuthController.java
+++ b/src/main/java/f4/auth/domain/auth/controller/AuthController.java
@@ -1,10 +1,10 @@
 package f4.auth.domain.auth.controller;
 
+import f4.auth.domain.auth.dto.request.CertificationRequestDto;
 import f4.auth.domain.auth.dto.request.LoginRequestDto;
 import f4.auth.domain.auth.dto.response.TokenResponseDto;
 import f4.auth.domain.auth.service.AuthService;
 import f4.auth.global.utils.CookieProvider;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,7 +14,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -59,7 +58,7 @@ public class AuthController {
   /*
    * @date : 2023.09.02
    * @author : yuki
-   * @param : @RequestHeader Authoriazation @CookieValue refresh-token
+   * @param : @RequestHeader Authorization @CookieValue refresh-token
    * @description : access-token이 만료된 경우 refresh-token 검증 후 새로운 access-token 발급
    */
   @PostMapping("/token/reissue")
@@ -79,16 +78,30 @@ public class AuthController {
   }
 
   /*
-  * @date : 2023,09.02
-  * @author : yuki
-  * @param : access-token
-  * @description : access-token 추출하여 만료시간 만큼 레디스의 블랙리스트에 저장해둠
-  */
+   * @date : 2023,09.02
+   * @author : yuki
+   * @param : access-token
+   * @description : access-token 추출하여 만료시간 만큼 레디스의 블랙리스트에 저장해둠
+   */
   @PatchMapping("/logout")
   public ResponseEntity<?> logout(@RequestHeader("Authorization") String accessToken) {
     log.info("로그아웃 수행.");
     authService.logout(accessToken);
     return ResponseEntity.status(HttpStatus.OK)
         .body("로그아웃에 성공하셨습니다.");
+  }
+
+  /*
+  * @date : 2023.09.04
+  * @author  : yuki
+  * @param : CertificationRequestDto ( email, certificationNUmber )
+  * @description : 레디스의 해당 이메일 인증 번호 확인
+  */
+  @PostMapping("/email/certification")
+  public ResponseEntity<?> emailCertification(@RequestBody CertificationRequestDto certificationRequestDto) {
+    log.info("회원가입 이메일 인증 수행. email : {}", certificationRequestDto.getEmail());
+    authService.emailCertification(certificationRequestDto);
+    return ResponseEntity.status(HttpStatus.OK)
+        .body("이메일이 인증되었습니다.");
   }
 }

--- a/src/main/java/f4/auth/domain/auth/dto/request/CertificationRequestDto.java
+++ b/src/main/java/f4/auth/domain/auth/dto/request/CertificationRequestDto.java
@@ -1,0 +1,22 @@
+package f4.auth.domain.auth.dto.request;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CertificationRequestDto {
+
+  @Email
+  @NotBlank
+  private String email;
+  @NotBlank
+  private String certificationNumber;
+}

--- a/src/main/java/f4/auth/domain/auth/service/AuthService.java
+++ b/src/main/java/f4/auth/domain/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package f4.auth.domain.auth.service;
 
+import f4.auth.domain.auth.dto.request.CertificationRequestDto;
 import f4.auth.domain.auth.dto.request.LoginRequestDto;
 import f4.auth.domain.auth.dto.response.TokenResponseDto;
 
@@ -10,4 +11,6 @@ public interface AuthService {
   TokenResponseDto reissue(String refreshToken);
 
   void logout(String accessToken);
+
+  void emailCertification(CertificationRequestDto certificationRequestDto);
 }

--- a/src/main/java/f4/auth/domain/auth/service/impl/AuthServiceImpl.java
+++ b/src/main/java/f4/auth/domain/auth/service/impl/AuthServiceImpl.java
@@ -1,6 +1,7 @@
 package f4.auth.domain.auth.service.impl;
 
 import f4.auth.domain.auth.dto.CreateTokenDto;
+import f4.auth.domain.auth.dto.request.CertificationRequestDto;
 import f4.auth.domain.auth.dto.request.LoginRequestDto;
 import f4.auth.domain.auth.dto.response.TokenResponseDto;
 import f4.auth.domain.auth.service.AuthService;
@@ -93,8 +94,22 @@ public class AuthServiceImpl implements AuthService {
     redisService.setBlackList(email, Duration.ofMillis(getExpiration(expired)));
   }
 
-  private Long getExpiration (Date expired){
-      Long now = new Date().getTime();
-      return expired.getTime() - now;
+  private Long getExpiration(Date expired) {
+    Long now = new Date().getTime();
+    return expired.getTime() - now;
+  }
+
+  @Override
+  public void emailCertification(CertificationRequestDto certificationRequestDto) {
+
+    if (!redisService.hasBlackList(certificationRequestDto.getEmail())) {
+      throw new CustomException(CustomErrorCode.TIMEOUT_CIRTIFICATION_NUMBER);
+    }
+
+    String certificationNumber = redisService.getData(certificationRequestDto.getEmail());
+
+    if (!certificationNumber.equals(certificationRequestDto.getCertificationNumber())) {
+      throw new CustomException(CustomErrorCode.INCORECT_CIRTIFICATION_NUMBER);
+    }
   }
 }

--- a/src/main/java/f4/auth/global/constant/CustomErrorCode.java
+++ b/src/main/java/f4/auth/global/constant/CustomErrorCode.java
@@ -14,6 +14,8 @@ public enum CustomErrorCode {
   ALREADY_LOGOUT_USER("/auth/v1/token/reissue", 400, "이미 로그아웃된 유저입니다."),
   NOT_EXIST_ROLE("/admin/..", 400, "해당 역할은 존재하지 않습니다."),
   NOT_VALID_ROLE("/admin/..", 400, "해당 API를 호출하기에 적합하지 않은 역할입니다."),
+  INCORECT_CIRTIFICATION_NUMBER("/auth/v1/email/certification", 400, "인증번호가 틀렸습니다."),
+  TIMEOUT_CIRTIFICATION_NUMBER("/auth/v1/email/certification", 400, "인증번호 입력 시간이 초과했습니다."),
 
   // Unathorized 401
   INVALID_ACCESS_TOKEN("/auth/v1/login", 401, "잘못된 토큰 입니다"),


### PR DESCRIPTION
## 🧑🏻‍💻 구현 기능
유효시간 3분 내에 이메일 인증 서비스를 진행하기 위한 API 작성

## 🤷🏻 동작 원리
1. 사용자가 이메일 인증 코드 받기 누를 시 email-service에서 인증 코드를 유효 시간 3분으로 발급
2. 이메일로 레디스의 접근하여 인증 번호를 꺼내와 비교한다.

## ✍🏻 To do
- [x] Email 인증 API 작성

## 관련 이슈
- Closed #21 
